### PR TITLE
Add/ci trivy scans

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -27,7 +27,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.TELESERVICES_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
-  build-push:
+          IGNORE_UNFIXED: 'false'
+  build-push-trivy-scan:
     runs-on: gha-runners-teleservices
     steps:
       - name: Build tags
@@ -67,3 +68,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.TELESERVICES_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
+          IGNORE_UNFIXED: 'false'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,69 @@
+name: Trivy security scan
+
+on:
+  push:
+  schedule:
+    - cron: '0 4 * * 1'  # Every Monday at 04:00 UTC
+  workflow_dispatch:
+env:
+  IMAGE_NAME: teleservices/bookworm
+  DEBIAN_VERSION: bookworm
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  trivy-fs:
+    name: Filesystem scan
+    runs-on: gha-runners-teleservices
+    steps:
+      - uses: IMIO/gha/trivy-scan-notify@v7
+        with:
+          SCAN_TYPE: fs
+          SCAN_REF: .
+          EXIT_CODE: '0'
+          TRIVYIGNORES: ''
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.TELESERVICES_MATTERMOST_WEBHOOK_URL }}
+          UPLOAD_SARIF: 'true'
+  build-push:
+    runs-on: gha-runners-teleservices
+    steps:
+      - name: Build tags
+        run: |
+          {
+            echo 'IMAGE_TAGS<<EOF'
+            echo '${{ env.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy'
+            echo '${{ env.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy-${{ github.run_number }}'
+            echo EOF
+          } >> $GITHUB_ENV
+      - name: Build push prod image (trivy) and notify
+        uses: IMIO/gha/build-push-notify@v7
+        with:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
+          REGISTRY_URL: ${{ env.HARBOR_URL}}
+          REGISTRY_USERNAME: ${{ secrets.TELESERVICES_HARBOR_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.TELESERVICES_HARBOR_PASSWORD }}
+          CONTEXT: 'teleservices'
+          DOCKERFILE: 'teleservices/Dockerfile'
+          BUILD_ARGS: 'DEBIAN_VERSION=${{ env.DEBIAN_VERSION }}'          
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.TELESERVICES_MATTERMOST_WEBHOOK_URL }}
+          TARGET: 'prod-image'          
+  trivy-image:
+    name: Image scan
+    runs-on: gha-runners-teleservices
+    needs: build-push
+    steps:
+      - uses: IMIO/gha/trivy-scan-notify@v7
+        with:
+          SCAN_TYPE: image
+          IMAGE_REF: ${{ secrets.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy
+          EXIT_CODE: '0'
+          TRIVYIGNORES: ''
+          TRIVY_USERNAME: ${{ secrets.TELESERVICES_HARBOR_USERNAME }}
+          TRIVY_PASSWORD: ${{ secrets.TELESERVICES_HARBOR_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.TELESERVICES_MATTERMOST_WEBHOOK_URL }}
+          UPLOAD_SARIF: 'true'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -85,3 +85,4 @@ jobs:
           TARGET: ${{ secrets.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy-${{ github.run_number }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          SEVERITIES: 'CRITICAL'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,7 +28,7 @@ jobs:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.TELESERVICES_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
           IGNORE_UNFIXED: 'false'
-  build-push-trivy-scan:
+  build-push:
     runs-on: gha-runners-teleservices
     steps:
       - name: Build tags

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,7 +1,6 @@
 name: Trivy security scan
 
 on:
-  push:
   schedule:
     - cron: '0 4 * * 1'  # Every Monday at 04:00 UTC
   workflow_dispatch:
@@ -14,20 +13,6 @@ permissions:
   security-events: write
 
 jobs:
-  trivy-fs:
-    name: Filesystem scan
-    runs-on: gha-runners-teleservices
-    steps:
-      - uses: IMIO/gha/trivy-scan-notify@v7
-        with:
-          SCAN_TYPE: fs
-          SCAN_REF: .
-          EXIT_CODE: '0'
-          TRIVYIGNORES: ''
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.TELESERVICES_MATTERMOST_WEBHOOK_URL }}
-          UPLOAD_SARIF: 'true'
-          IGNORE_UNFIXED: 'false'
   build-push:
     runs-on: gha-runners-teleservices
     steps:
@@ -56,11 +41,17 @@ jobs:
     name: Image scan
     runs-on: gha-runners-teleservices
     needs: build-push
+    outputs:
+      critical: ${{ steps.trivy.outputs.critical }}
+      high: ${{ steps.trivy.outputs.high }}
+      json_file: ${{ steps.trivy.outputs.json_file }}
+      artifact_name: ${{ steps.trivy.outputs.artifact_name }}
     steps:
-      - uses: IMIO/gha/trivy-scan-notify@v7
+      - id: trivy
+        uses: IMIO/gha/trivy-scan-notify@v7
         with:
           SCAN_TYPE: image
-          IMAGE_REF: ${{ secrets.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy
+          IMAGE_REF: ${{ secrets.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy-${{ github.run_number }}
           EXIT_CODE: '0'
           TRIVYIGNORES: ''
           TRIVY_USERNAME: ${{ secrets.TELESERVICES_HARBOR_USERNAME }}
@@ -69,3 +60,28 @@ jobs:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.TELESERVICES_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
           IGNORE_UNFIXED: 'false'
+
+  trivy-claude-image:
+    name: Claude advisory analysis (image)
+    needs: trivy-image
+    if: needs.trivy-image.outputs.critical > 0 || needs.trivy-image.outputs.high > 0
+    environment: security-review
+    runs-on: gha-runners-smartweb
+    permissions:
+      contents: read
+    steps:
+      - id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.ADVISORY_APP_ID }}
+          private-key: ${{ secrets.ADVISORY_APP_SECRET }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.trivy-image.outputs.artifact_name }}
+      - uses: IMIO/gha/trivy-claude-analysis@v7
+        with:
+          JSON_FILE: ${{ needs.trivy-image.outputs.json_file }}
+          SCAN_TYPE: image
+          TARGET: ${{ secrets.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy-${{ github.run_number }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,8 +34,8 @@ jobs:
         run: |
           {
             echo 'IMAGE_TAGS<<EOF'
-            echo '${{ env.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy'
-            echo '${{ env.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy-${{ github.run_number }}'
+            echo '${{ secrets.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy'
+            echo '${{ secrets.HARBOR_URL }}/${{ env.IMAGE_NAME }}:trivy-${{ github.run_number }}'
             echo EOF
           } >> $GITHUB_ENV
       - name: Build push prod image (trivy) and notify
@@ -43,7 +43,7 @@ jobs:
         with:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
-          REGISTRY_URL: ${{ env.HARBOR_URL}}
+          REGISTRY_URL: ${{ secrets.HARBOR_URL}}
           REGISTRY_USERNAME: ${{ secrets.TELESERVICES_HARBOR_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.TELESERVICES_HARBOR_PASSWORD }}
           CONTEXT: 'teleservices'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated security scanning with scheduled weekly runs and a manual trigger.
  * Builds and tags a scan image, runs Trivy image scans, uploads SARIF/artifact results, and exports critical/high counts.
  * Critical or high-severity findings initiate an advisory analysis and send notifications for follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->